### PR TITLE
Add /docs/m2-customer-codes to qa and prod

### DIFF
--- a/config/var_production.env
+++ b/config/var_production.env
@@ -3,8 +3,8 @@ DOCS_HOST=platform.nypl.org
 DOCS_S3_BUCKET=platformdocs.nypl.org
 DOCS_S3_CACHE_SECONDS=0
 DOCS_S3_KEY=api/list.json
-DOCS_URLS=/docs/barcode,/docs/bib,/docs/book-lists,/docs/check-in-cards,/docs/checkin-requests,/docs/checkin-requests-sync,/docs/checkout-requests,/docs/checkout-requests-sync,/docs/discovery,/docs/doc,/docs/hold-requests,/docs/is-research,/docs/item,/docs/job,/docs/mylibrarynyc,/docs/patron,/docs/patron-hold-request-eligibility,/docs/patrons-validations,/docs/recap-bibs,/docs/recap-hold-requests,/docs/refile-requests,/docs/schema,/docs/sync-item-metadata-to-scsb
-DOCS_EXTERNAL_DESCRIPTION=Documentation for using the Platform APIs
+DOCS_URLS=/docs/barcode,/docs/bib,/docs/book-lists,/docs/check-in-cards,/docs/checkin-requests,/docs/checkin-requests-sync,/docs/checkout-requests,/docs/checkout-requests-sync,/docs/discovery,/docs/doc,/docs/hold-requests,/docs/is-research,/docs/item,/docs/job,/docs/mylibrarynyc,/docs/patron,/docs/patron-hold-request-eligibility,/docs/patrons-validations,/docs/recap-bibs,/docs/recap-hold-requests,/docs/refile-requests,/docs/schema,/docs/sync-item-metadata-to-scsb,/docs/m2-customer-codes
+DOCS_EXTERNAL_DESCRIPTION='Documentation for using the Platform APIs'
 DOCS_EXTERNAL_URL=https://docs.google.com/document/d/1p3q9OT9latXqON20WDh4CNPxIShUunfGgqT163r-Caw/edit?usp=sharing
 DOCS_INFO_VERSION=production
 DOCS_INFO_DESCRIPTION=Endpoints require an OpenID Connect token from the NYPL OAuth server and interact with NYPL Data Streams.

--- a/config/var_qa.env
+++ b/config/var_qa.env
@@ -3,8 +3,8 @@ DOCS_HOST=qa-platform.nypl.org
 DOCS_S3_BUCKET=qa-platformdocs.nypl.org
 DOCS_S3_CACHE_SECONDS=0
 DOCS_S3_KEY=api/list.json
-DOCS_URLS=/docs/bib,/docs/book-lists,/docs/check-in-cards,/docs/checkin-requests,/docs/checkin-requests-sync,/docs/checkout-requests,/docs/checkout-requests-sync,/docs/discovery,/docs/doc,/docs/hold-requests,/docs/is-research,/docs/item,/docs/job,/docs/mylibrarynyc,/docs/patron,/docs/patron-hold-request-eligibility,/docs/patrons-validations,/docs/recap-bibs,/docs/recap-hold-requests,/docs/refile-requests,/docs/schema,/docs/sync-item-metadata-to-scsb
-DOCS_EXTERNAL_DESCRIPTION=Documentation for using the Platform APIs
+DOCS_URLS=/docs/bib,/docs/book-lists,/docs/check-in-cards,/docs/checkin-requests,/docs/checkin-requests-sync,/docs/checkout-requests,/docs/checkout-requests-sync,/docs/discovery,/docs/doc,/docs/hold-requests,/docs/is-research,/docs/item,/docs/job,/docs/mylibrarynyc,/docs/patron,/docs/patron-hold-request-eligibility,/docs/patrons-validations,/docs/recap-bibs,/docs/recap-hold-requests,/docs/refile-requests,/docs/schema,/docs/sync-item-metadata-to-scsb,/docs/m2-customer-codes
+DOCS_EXTERNAL_DESCRIPTION='Documentation for using the Platform APIs'
 DOCS_EXTERNAL_URL=https://docs.google.com/document/d/1p3q9OT9latXqON20WDh4CNPxIShUunfGgqT163r-Caw/edit?usp=sharing
 DOCS_INFO_VERSION=qa
 DOCS_INFO_DESCRIPTION=Endpoints require an OpenID Connect token from the NYPL OAuth server and interact with NYPL Data Streams.


### PR DESCRIPTION
We do need to add this config afterall.

I have updated guidance [here](https://github.com/NYPL/lsp_workflows/pull/18)