### PR TITLE
TGR-74: Removing the barcodeServices URL from development and prod configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,6 @@ In general we would like the `DOCS_URLS` config to be equal across deployments. 
  - /docs/refile-requests
  - /docs/sync-item-metadata-to-scsb
 
-**In qa**, we can not use the following docs endpoints because they either don't exist or are broken:
- - /docs/barcode
-
 ## Usage
 
 ### Process a Lambda Event

--- a/config/var_development.env
+++ b/config/var_development.env
@@ -4,4 +4,4 @@ DOCS_INFO_VERSION=development
 DOCS_S3_BUCKET=dev-platformdocs.nypl.org
 DOCS_S3_CACHE_SECONDS=0
 DOCS_S3_KEY=api/list.json
-DOCS_URLS=/docs/barcode,/docs/bib,/docs/book-lists,/docs/checkin-requests,/docs/checkout-requests,/docs/doc,/docs/hold-requests,/docs/item,/docs/job,/docs/patron,/docs/patron-hold-request-eligibility,/docs/recap-bibs,/docs/recap-hold-requests,/docs/schema
+DOCS_URLS=/docs/bib,/docs/book-lists,/docs/checkin-requests,/docs/checkout-requests,/docs/doc,/docs/hold-requests,/docs/item,/docs/job,/docs/patron,/docs/patron-hold-request-eligibility,/docs/recap-bibs,/docs/recap-hold-requests,/docs/schema

--- a/config/var_production.env
+++ b/config/var_production.env
@@ -3,7 +3,7 @@ DOCS_HOST=platform.nypl.org
 DOCS_S3_BUCKET=platformdocs.nypl.org
 DOCS_S3_CACHE_SECONDS=0
 DOCS_S3_KEY=api/list.json
-DOCS_URLS=/docs/barcode,/docs/bib,/docs/book-lists,/docs/check-in-cards,/docs/checkin-requests,/docs/checkin-requests-sync,/docs/checkout-requests,/docs/checkout-requests-sync,/docs/discovery,/docs/doc,/docs/hold-requests,/docs/is-research,/docs/item,/docs/job,/docs/mylibrarynyc,/docs/patron,/docs/patron-hold-request-eligibility,/docs/patrons-validations,/docs/recap-bibs,/docs/recap-hold-requests,/docs/refile-requests,/docs/schema,/docs/sync-item-metadata-to-scsb,/docs/m2-customer-codes
+DOCS_URLS=/docs/bib,/docs/book-lists,/docs/check-in-cards,/docs/checkin-requests,/docs/checkin-requests-sync,/docs/checkout-requests,/docs/checkout-requests-sync,/docs/discovery,/docs/doc,/docs/hold-requests,/docs/is-research,/docs/item,/docs/job,/docs/mylibrarynyc,/docs/patron,/docs/patron-hold-request-eligibility,/docs/patrons-validations,/docs/recap-bibs,/docs/recap-hold-requests,/docs/refile-requests,/docs/schema,/docs/sync-item-metadata-to-scsb,/docs/m2-customer-codes
 DOCS_EXTERNAL_DESCRIPTION='Documentation for using the Platform APIs'
 DOCS_EXTERNAL_URL=https://docs.google.com/document/d/1p3q9OT9latXqON20WDh4CNPxIShUunfGgqT163r-Caw/edit?usp=sharing
 DOCS_INFO_VERSION=production


### PR DESCRIPTION
This partly resolves [TGR-74](https://newyorkpubliclibrary.atlassian.net/browse/TGR-74).

- It removes any references to the `/docs/barcodes` endpoint so that `/v0.1/patrons/{id}/barcode` won't render in the prod Swagger docs.
- This endpoint is already broken on QA and doesn't appear so there's only one environment this can be tested on.
- I actually can't _run_ this repo but the changes are config and don't affect how the code is run. Not sure if I can run this in order to deploy the updates.
- The next step before or after this PR is merged in is to remove the endpoint from API Gateway.

[TGR-74]: https://newyorkpubliclibrary.atlassian.net/browse/TGR-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ